### PR TITLE
Users can manage tags only on posts they created

### DIFF
--- a/src/components/posts/PostDetail.js
+++ b/src/components/posts/PostDetail.js
@@ -6,6 +6,7 @@ import { PostContext } from './PostProvider'
 export const PostDetail = () => {
     const { getPostById } = useContext(PostContext);
     const [postDetail, setPostDetail] = useState({})
+    const userId = parseInt(localStorage.getItem(`rare_user_id`))
     const {postId} = useParams();
     const history = useHistory();
 
@@ -27,7 +28,11 @@ export const PostDetail = () => {
             <section className="content">{postDetail.content}</section>
         </article>
         <div className="manage_tags">
-            <button className="post_tags" onClick={() => history.push(`/posts/detail/${postId}/tags`)}>Manage Tags</button>
+            { userId === postDetail.userId ?
+                <section>
+                    <div>Tags: {postDetail.tags.map(tag => tag.label).join(", ")}</div>
+                <button className="post_tags" onClick={() => history.push(`/posts/detail/${postId}/tags`)}>Manage Tags</button></section>
+            : <></>}  
         </div>
     
     </>


### PR DESCRIPTION
# Description
Users can manage tags only on posts they created

Fixes #11 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# Testing Instructions

```
git fetch --all
git checkout sl-tag-detail
```

# Checklist:
- [ ]  See my posts to manage tags
- [ ] See All post manage tag button should NOT show
 
